### PR TITLE
fix: reconnect in tests would hit localhost 1774

### DIFF
--- a/logd/config.go
+++ b/logd/config.go
@@ -184,10 +184,13 @@ var DefaultBenchConfig = &BenchConfig{
 	Verbose: false,
 }
 
+var cachedPort = 4771
+
 // DefaultTestConfig returns a testing configuration
 func DefaultTestConfig(verbose bool) *Config {
 	c := &Config{}
 	*c = *DefaultConfig
+	c.Host = fmt.Sprintf("127.0.0.1:%d", cachedPort)
 	c.Verbose = verbose
 	c.BatchSize = 1024 * 20
 	c.ReadTimeout = 100 * time.Millisecond


### PR DESCRIPTION
This only affected tests that used net.Pipe as far as I can tell.

confusing enough when trying to run tests to fix.


---

This PR should adhere to [conventional commit 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).  This section should contain the optional body and footer. __This section may not make it into the commit message! Please make sure to copy it there if desired!__

The following types can be used, in order of precedence:

- feat
- fix
- cont
- refactor
- doc
- perf
- test
- chore
- revert

Regarding precedence, for example, if the PR contains both a `feat` and a `doc` type, the title should be `feat`.

In addition to the `BREAKING CHANGE` footer, the following can also be used:

- `NOTE` for general notes
- `UPCOMING CHANGE` for upcoming breaking changes prepared by this change